### PR TITLE
Bug fix: Nested directories not working

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -24,7 +24,7 @@ var engine = function engine(req, res, next) {
   res.render = function _render(view, options, callback) {
     var self = this;
 
-    render.call(self, view.replace('.', '/'), options, callback);
+    render.call(self, view.replace(/\./gi, '/'), options, callback);
   };
 
   /*

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const engine = (req, res, next) => {
   res.render = function _render(view, options, callback) {
     const self = this;
 
-    render.call(self, view.replace('.', '/'), options, callback);
+    render.call(self, view.replace(/\./gi, '/'), options, callback);
   };
 
   /*


### PR DESCRIPTION
Only the first instance of '.' was being replaced into forward slashes '/'. in the specified file path due to the _render function using a substr pattern for String.prototype.replace() causing such code to crash the application due to a non-resolving file path.
`res.render('main.blogs.index')`

I replaced the pattern into a regexp which replaces all instances of '.' into '/'. in the specified file path.

Without the fix to render _views/main/blogs/index.edge_ the workaround was as follows
`res.render('main/blogs.index')`
or
`res.render('main.blogs/index')`

With the fix the following format is usable
`res.render('main.blogs.index')`

This mirrors Laravel blade functionality and enables nesting of more than one folder under the view directory. I hope this is of great help!

**Edit:** This mirrors Adonis Edge as well as seen in the docs https://adonisjs.com/docs/4.1/views

```
// file path: resources/views/my/nested/view.edge

view.render('my.nested.view')
```