### PR TITLE
Upgrade dependencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,15 @@
+'use strict';
+
 module.exports = {
   extends: 'airbnb-base',
+  rules: {
+    strict: [2, 'global'],
+  },
   parserOptions: {
     sourceType: 'script',
   },
   env: {
     browser: true,
     node: true,
-  }
+  },
 };

--- a/README.md
+++ b/README.md
@@ -22,10 +22,7 @@ See the [Edge documentation](http://edge.adonisjs.com/) for how to structure you
 ```javascript
 const express = require('express');
 const app = express();
-const { config, engine } = require('express-edge');
-
-// Configure Edge if need to
-config({ cache: process.env.NODE_ENV === 'production' });
+const { engine } = require('express-edge');
 
 // Automatically sets view engine and adds dot notation to app.render
 app.use(engine);

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,16 +1,6 @@
 'use strict';
 
-var fs = require('fs');
-var edge = require('edge.js');
-
-var config = function config() {
-  var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : { cache: false },
-      cache = _ref.cache;
-
-  edge.configure({
-    cache: cache
-  });
-};
+var edge = require('edge.js').default;
 
 var engine = function engine(req, res, next) {
   /*
@@ -34,14 +24,12 @@ var engine = function engine(req, res, next) {
   */
 
   req.app.engine('edge', function (filePath, options, callback) {
-    edge.registerViews(req.app.settings.views);
+    edge.mount(req.app.settings.views);
 
-    fs.readFile(filePath, 'utf-8', function (err, content) {
-      if (err) {
-        return callback(err);
-      }
-
-      return callback(null, edge.renderString(content, options));
+    edge.render(filePath, options).then(function (content) {
+      return callback(null, content);
+    }).catch(function (err) {
+      return callback(err);
     });
   });
 
@@ -56,4 +44,4 @@ var engine = function engine(req, res, next) {
   next();
 };
 
-module.exports = { config: config, engine: engine };
+module.exports = { engine: engine };

--- a/dist/index.js
+++ b/dist/index.js
@@ -11,6 +11,7 @@ var engine = function engine(req, res, next) {
 
   var render = res.render;
 
+
   res.render = function _render(view, options, callback) {
     var self = this;
 

--- a/package.json
+++ b/package.json
@@ -43,14 +43,14 @@
     "babel-preset-env": "^1.6.1",
     "body-parser": "^1.18.2",
     "chai": "^4.1.0",
-    "eslint": "^4.12.1",
-    "eslint-config-airbnb-base": "^11.2.0",
+    "eslint": "^8.3.0",
+    "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.7.0",
-    "express": "^4.16.2",
-    "mocha": "^3.4.2",
-    "supertest": "^3.0.0"
+    "express": "^4.17.1",
+    "mocha": "^9.1.3",
+    "supertest": "^6.1.6"
   },
   "dependencies": {
-    "edge.js": "^1.1.4"
+    "edge.js": "^5.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-edge",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "Use Edge templating engine with Express",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,6 @@
 'use strict';
 
-const fs = require('fs');
-const edge = require('edge.js');
-
-const config = ({ cache } = { cache: false }) => {
-  edge.configure({
-    cache,
-  });
-};
+const edge = require('edge.js').default;
 
 const engine = (req, res, next) => {
   /*
@@ -31,15 +24,11 @@ const engine = (req, res, next) => {
   */
 
   req.app.engine('edge', (filePath, options, callback) => {
-    edge.registerViews(req.app.settings.views);
+    edge.mount(req.app.settings.views);
 
-    fs.readFile(filePath, 'utf-8', (err, content) => {
-      if (err) {
-        return callback(err);
-      }
-
-      return callback(null, edge.renderString(content, options));
-    });
+    edge.render(filePath, options)
+      .then((content) => callback(null, content))
+      .catch((err) => callback(err));
   });
 
   /*
@@ -53,4 +42,4 @@ const engine = (req, res, next) => {
   next();
 };
 
-module.exports = { config, engine };
+module.exports = { engine };

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const engine = (req, res, next) => {
   |-------------------------------------------------------------------------------------------------
   */
 
-  const render = res.render;
+  const { render } = res;
 
   res.render = function _render(view, options, callback) {
     const self = this;

--- a/test/tests.js
+++ b/test/tests.js
@@ -6,7 +6,7 @@ const bodyParser = require('body-parser');
 const { describe, it, before } = require('mocha');
 const { expect } = require('chai');
 const request = require('supertest');
-const dist = require('../dist');
+const { engine } = require('../dist');
 
 let app;
 
@@ -16,7 +16,7 @@ describe('View Test Suite', () => {
     app = express();
 
     app.use(bodyParser.json());
-    app.use(dist.engine);
+    app.use(engine);
 
     app.set('views', `${__dirname}/views`);
 
@@ -113,7 +113,7 @@ describe('Cache Test Suite', () => {
     process.env.CACHE_VIEWS = '1';
 
     app.use(bodyParser.json());
-    app.use(dist.engine);
+    app.use(engine);
 
     app.set('views', `${__dirname}/views`);
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -12,7 +12,7 @@ let app;
 
 describe('View Test Suite', () => {
   before(() => {
-    process.env.CACHE_VIEWS = ''; // false
+    process.env.CACHE_VIEWS = false;
     app = express();
 
     app.use(bodyParser.json());
@@ -110,7 +110,7 @@ describe('Cache Test Suite', () => {
   before(() => {
     app = express();
 
-    process.env.CACHE_VIEWS = '1';
+    process.env.CACHE_VIEWS = true;
 
     app.use(bodyParser.json());
     app.use(engine);

--- a/test/views/layout.edge
+++ b/test/views/layout.edge
@@ -1,0 +1,4 @@
+@layout('main')
+@section('body')
+jhon doe
+@end

--- a/test/views/main.edge
+++ b/test/views/main.edge
@@ -1,0 +1,3 @@
+base layout
+@!section('body')
+

--- a/test/views/sub/hello_uncached.edge
+++ b/test/views/sub/hello_uncached.edge
@@ -1,0 +1,1 @@
+hello worlds


### PR DESCRIPTION
upgrade edge.js to the latest versions so that it's possible to use the new features. Took the opportunity to upgrade others' outdated dependencies.

- "eslint": "^8.3.0",
-  "eslint-config-airbnb-base": "^15.0.0",
- "express": "^4.17.1",
- "mocha": "^9.1.3",
- "supertest": "^6.1.6"
- "edge.js": "^5.3.2"